### PR TITLE
Fix optional dependency import

### DIFF
--- a/jsonutils/base.py
+++ b/jsonutils/base.py
@@ -10,7 +10,10 @@ from pathlib import Path
 from typing import List, Union
 from uuid import uuid4
 
-import pyperclip
+try:
+    import pyperclip
+except ImportError:  # pragma: no cover - optional dependency
+    pyperclip = None
 import requests
 from bs4 import BeautifulSoup
 
@@ -264,6 +267,10 @@ class JSONObject:
 
     @classmethod
     def read_from_clipboard(cls):
+        if pyperclip is None:
+            raise ImportError(
+                "pyperclip is required for reading from clipboard"
+            )
         clipboard_data = pyperclip.paste()
         return cls.loads(clipboard_data)
 


### PR DESCRIPTION
## Summary
- make `pyperclip` optional so library can load when it's not installed

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'requests')*

------
https://chatgpt.com/codex/tasks/task_e_6841c53362a0832ba0ec45c549438309